### PR TITLE
Station search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ xcuserdata
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
+Environmet.swift
 
 ## Obj-C/Swift specific
 *.hmap

--- a/Environment.swift
+++ b/Environment.swift
@@ -1,0 +1,15 @@
+//
+//  Environment.swift
+//  SL One trip search
+//
+//  Created by Emil Lundgren on 2018-10-18.
+//  Copyright © 2018 Kebne. All rights reserved.
+//
+
+import Foundation
+
+
+enum Environment {
+    static let stationAPIKey = "794d89c8dc0245708e4b1d0385ce571f"
+}
+

--- a/SL One trip search.xcodeproj/project.pbxproj
+++ b/SL One trip search.xcodeproj/project.pbxproj
@@ -23,6 +23,13 @@
 		5135EF8C21777E790016AAD6 /* UserJourneyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF8B21777E790016AAD6 /* UserJourneyController.swift */; };
 		5135EF8E217780050016AAD6 /* ViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF8D217780050016AAD6 /* ViewControllerFactory.swift */; };
 		5135EF90217887510016AAD6 /* UserJourneyControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF8F217887510016AAD6 /* UserJourneyControllerTests.swift */; };
+		5135EF922178BD8F0016AAD6 /* StationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF912178BD8F0016AAD6 /* StationTableViewCell.swift */; };
+		5135EF942178C8440016AAD6 /* SLSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF932178C8440016AAD6 /* SLSearch.swift */; };
+		5135EF962178C8840016AAD6 /* SearchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF952178C8830016AAD6 /* SearchRequest.swift */; };
+		5135EF982178CBBE0016AAD6 /* Environment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF972178CBBE0016AAD6 /* Environment.swift */; };
+		5135EF9C2178D5D20016AAD6 /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF9B2178D5D20016AAD6 /* SettingsViewModelTests.swift */; };
+		5135EF9E2178D9560016AAD6 /* SearchRequestTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF9D2178D9560016AAD6 /* SearchRequestTest.swift */; };
+		5135EFA02178E04F0016AAD6 /* SLSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF9F2178E04F0016AAD6 /* SLSearchTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +72,13 @@
 		5135EF8B21777E790016AAD6 /* UserJourneyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserJourneyController.swift; sourceTree = "<group>"; };
 		5135EF8D217780050016AAD6 /* ViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewControllerFactory.swift; sourceTree = "<group>"; };
 		5135EF8F217887510016AAD6 /* UserJourneyControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserJourneyControllerTests.swift; sourceTree = "<group>"; };
+		5135EF912178BD8F0016AAD6 /* StationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationTableViewCell.swift; sourceTree = "<group>"; };
+		5135EF932178C8440016AAD6 /* SLSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SLSearch.swift; sourceTree = "<group>"; };
+		5135EF952178C8830016AAD6 /* SearchRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRequest.swift; sourceTree = "<group>"; };
+		5135EF972178CBBE0016AAD6 /* Environment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Environment.swift; sourceTree = "<group>"; };
+		5135EF9B2178D5D20016AAD6 /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
+		5135EF9D2178D9560016AAD6 /* SearchRequestTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRequestTest.swift; sourceTree = "<group>"; };
+		5135EF9F2178E04F0016AAD6 /* SLSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SLSearchTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +109,7 @@
 		5135EF4021776AB30016AAD6 = {
 			isa = PBXGroup;
 			children = (
+				5135EF972178CBBE0016AAD6 /* Environment.swift */,
 				5135EF4B21776AB30016AAD6 /* SL One trip search */,
 				5135EF6021776AB50016AAD6 /* SL One trip searchTests */,
 				5135EF6B21776AB60016AAD6 /* SL One trip searchUITests */,
@@ -135,6 +150,9 @@
 				5135EF6121776AB50016AAD6 /* SL_One_trip_searchTests.swift */,
 				5135EF6321776AB50016AAD6 /* Info.plist */,
 				5135EF8F217887510016AAD6 /* UserJourneyControllerTests.swift */,
+				5135EF9B2178D5D20016AAD6 /* SettingsViewModelTests.swift */,
+				5135EF9D2178D9560016AAD6 /* SearchRequestTest.swift */,
+				5135EF9F2178E04F0016AAD6 /* SLSearchTests.swift */,
 			);
 			path = "SL One trip searchTests";
 			sourceTree = "<group>";
@@ -154,6 +172,7 @@
 				5135EF4E21776AB30016AAD6 /* JourneyViewController.swift */,
 				5135EF7C217774200016AAD6 /* SearchViewController.swift */,
 				5135EF7A217774110016AAD6 /* SettingsViewController.swift */,
+				5135EF912178BD8F0016AAD6 /* StationTableViewCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -179,6 +198,8 @@
 		5135EF81217774540016AAD6 /* Service */ = {
 			isa = PBXGroup;
 			children = (
+				5135EF932178C8440016AAD6 /* SLSearch.swift */,
+				5135EF952178C8830016AAD6 /* SearchRequest.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -326,12 +347,16 @@
 				5135EF8C21777E790016AAD6 /* UserJourneyController.swift in Sources */,
 				5135EF8E217780050016AAD6 /* ViewControllerFactory.swift in Sources */,
 				5135EF4F21776AB30016AAD6 /* JourneyViewController.swift in Sources */,
+				5135EF982178CBBE0016AAD6 /* Environment.swift in Sources */,
+				5135EF922178BD8F0016AAD6 /* StationTableViewCell.swift in Sources */,
+				5135EF962178C8840016AAD6 /* SearchRequest.swift in Sources */,
 				5135EF4D21776AB30016AAD6 /* AppDelegate.swift in Sources */,
 				5135EF8621777D420016AAD6 /* UserJourney.swift in Sources */,
 				5135EF7D217774200016AAD6 /* SearchViewController.swift in Sources */,
 				5135EF842177747F0016AAD6 /* MainCoordinator.swift in Sources */,
 				5135EF8A21777E6B0016AAD6 /* StateController.swift in Sources */,
 				5135EF7B217774110016AAD6 /* SettingsViewController.swift in Sources */,
+				5135EF942178C8440016AAD6 /* SLSearch.swift in Sources */,
 				5135EF8821777D820016AAD6 /* Station.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -340,8 +365,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5135EFA02178E04F0016AAD6 /* SLSearchTests.swift in Sources */,
 				5135EF90217887510016AAD6 /* UserJourneyControllerTests.swift in Sources */,
+				5135EF9E2178D9560016AAD6 /* SearchRequestTest.swift in Sources */,
 				5135EF6221776AB50016AAD6 /* SL_One_trip_searchTests.swift in Sources */,
+				5135EF9C2178D5D20016AAD6 /* SettingsViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SL One trip search.xcodeproj/project.pbxproj
+++ b/SL One trip search.xcodeproj/project.pbxproj
@@ -30,6 +30,9 @@
 		5135EF9C2178D5D20016AAD6 /* SettingsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF9B2178D5D20016AAD6 /* SettingsViewModelTests.swift */; };
 		5135EF9E2178D9560016AAD6 /* SearchRequestTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF9D2178D9560016AAD6 /* SearchRequestTest.swift */; };
 		5135EFA02178E04F0016AAD6 /* SLSearchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EF9F2178E04F0016AAD6 /* SLSearchTests.swift */; };
+		5135EFA22179FC830016AAD6 /* PersistService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EFA12179FC830016AAD6 /* PersistService.swift */; };
+		5135EFA4217A166B0016AAD6 /* StationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EFA3217A166B0016AAD6 /* StationTests.swift */; };
+		5135EFA6217A19250016AAD6 /* PersistServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5135EFA5217A19250016AAD6 /* PersistServiceTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -79,6 +82,9 @@
 		5135EF9B2178D5D20016AAD6 /* SettingsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModelTests.swift; sourceTree = "<group>"; };
 		5135EF9D2178D9560016AAD6 /* SearchRequestTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRequestTest.swift; sourceTree = "<group>"; };
 		5135EF9F2178E04F0016AAD6 /* SLSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SLSearchTests.swift; sourceTree = "<group>"; };
+		5135EFA12179FC830016AAD6 /* PersistService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistService.swift; sourceTree = "<group>"; };
+		5135EFA3217A166B0016AAD6 /* StationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationTests.swift; sourceTree = "<group>"; };
+		5135EFA5217A19250016AAD6 /* PersistServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistServiceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -153,6 +159,8 @@
 				5135EF9B2178D5D20016AAD6 /* SettingsViewModelTests.swift */,
 				5135EF9D2178D9560016AAD6 /* SearchRequestTest.swift */,
 				5135EF9F2178E04F0016AAD6 /* SLSearchTests.swift */,
+				5135EFA3217A166B0016AAD6 /* StationTests.swift */,
+				5135EFA5217A19250016AAD6 /* PersistServiceTests.swift */,
 			);
 			path = "SL One trip searchTests";
 			sourceTree = "<group>";
@@ -200,6 +208,7 @@
 			children = (
 				5135EF932178C8440016AAD6 /* SLSearch.swift */,
 				5135EF952178C8830016AAD6 /* SearchRequest.swift */,
+				5135EFA12179FC830016AAD6 /* PersistService.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -350,6 +359,7 @@
 				5135EF982178CBBE0016AAD6 /* Environment.swift in Sources */,
 				5135EF922178BD8F0016AAD6 /* StationTableViewCell.swift in Sources */,
 				5135EF962178C8840016AAD6 /* SearchRequest.swift in Sources */,
+				5135EFA22179FC830016AAD6 /* PersistService.swift in Sources */,
 				5135EF4D21776AB30016AAD6 /* AppDelegate.swift in Sources */,
 				5135EF8621777D420016AAD6 /* UserJourney.swift in Sources */,
 				5135EF7D217774200016AAD6 /* SearchViewController.swift in Sources */,
@@ -368,7 +378,9 @@
 				5135EFA02178E04F0016AAD6 /* SLSearchTests.swift in Sources */,
 				5135EF90217887510016AAD6 /* UserJourneyControllerTests.swift in Sources */,
 				5135EF9E2178D9560016AAD6 /* SearchRequestTest.swift in Sources */,
+				5135EFA6217A19250016AAD6 /* PersistServiceTests.swift in Sources */,
 				5135EF6221776AB50016AAD6 /* SL_One_trip_searchTests.swift in Sources */,
+				5135EFA4217A166B0016AAD6 /* StationTests.swift in Sources */,
 				5135EF9C2178D5D20016AAD6 /* SettingsViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SL One trip search/AppDelegate.swift
+++ b/SL One trip search/AppDelegate.swift
@@ -16,8 +16,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
-  
-        let userController = UserJourneyController()
+        let persistService = PersistService()
+        let userController = UserJourneyController(persistService: persistService)
+        userController.attemptToRetreiveStoredJourney()
         let stateController = StateController(userController: userController)
         window = UIWindow(frame: UIScreen.main.bounds)
         let rootNavController = UINavigationController()

--- a/SL One trip search/Base.lproj/Main.storyboard
+++ b/SL One trip search/Base.lproj/Main.storyboard
@@ -145,13 +145,66 @@
                     <view key="view" contentMode="scaleToFill" id="GLa-rc-gsO">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="rLw-hM-TQV">
+                                <rect key="frame" x="0.0" y="44" width="375" height="734"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="StationTableViewCell" rowHeight="65" id="lgD-HK-0hb" customClass="StationTableViewCell" customModule="SL_One_trip_search" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="65"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lgD-HK-0hb" id="GxT-ru-n0l">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="64.666666666666671"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="lar-pS-mi3">
+                                                    <rect key="frame" x="25" y="21" width="325" height="36"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xmT-pP-NPb">
+                                                            <rect key="frame" x="0.0" y="0.0" width="45" height="20.333333333333332"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Area" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bLj-6B-fJ3">
+                                                            <rect key="frame" x="0.0" y="20.333333333333336" width="28" height="15.666666666666664"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                            <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="lar-pS-mi3" firstAttribute="leading" secondItem="GxT-ru-n0l" secondAttribute="leadingMargin" constant="10" id="0lL-qc-J2N"/>
+                                                <constraint firstItem="lar-pS-mi3" firstAttribute="top" secondItem="GxT-ru-n0l" secondAttribute="topMargin" constant="10" id="7uT-UF-4Z5"/>
+                                                <constraint firstAttribute="trailingMargin" secondItem="lar-pS-mi3" secondAttribute="trailing" constant="10" id="xsJ-1z-LxD"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="additionalNameLabel" destination="bLj-6B-fJ3" id="Qi4-oa-Ta3"/>
+                                            <outlet property="nameLabel" destination="xmT-pP-NPb" id="5vL-iM-lSL"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="rLw-hM-TQV" firstAttribute="top" secondItem="d8b-hc-X0e" secondAttribute="top" id="Qy2-Ms-zIa"/>
+                            <constraint firstItem="d8b-hc-X0e" firstAttribute="trailing" secondItem="rLw-hM-TQV" secondAttribute="trailing" id="aEA-sp-8V7"/>
+                            <constraint firstItem="d8b-hc-X0e" firstAttribute="bottom" secondItem="rLw-hM-TQV" secondAttribute="bottom" id="dKw-R0-6vP"/>
+                            <constraint firstItem="rLw-hM-TQV" firstAttribute="leading" secondItem="d8b-hc-X0e" secondAttribute="leading" id="rni-uH-cda"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="d8b-hc-X0e"/>
                     </view>
+                    <connections>
+                        <outlet property="searchTableView" destination="rLw-hM-TQV" id="no3-UR-gi4"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0IQ-Rr-Ypa" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2092" y="71.514242878560722"/>
+            <point key="canvasLocation" x="2092" y="70.935960591133011"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="X9n-Ec-KvZ">

--- a/SL One trip search/Base.lproj/Main.storyboard
+++ b/SL One trip search/Base.lproj/Main.storyboard
@@ -19,7 +19,13 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
-                    <navigationItem key="navigationItem" id="RqS-9d-dGy"/>
+                    <navigationItem key="navigationItem" id="RqS-9d-dGy">
+                        <barButtonItem key="rightBarButtonItem" systemItem="search" id="ahB-WM-CoO">
+                            <connections>
+                                <action selector="didPressSettingsButton:" destination="BYZ-38-t0r" id="hno-2Y-1PF"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/SL One trip search/Controller/StateController.swift
+++ b/SL One trip search/Controller/StateController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 protocol StateControllerProtocol {
-    var userJourneyController: UserJourneyControllerProtocol {get}
+    var userJourneyController: UserJourneyControllerProtocol {get set}
     
     init(userController: UserJourneyControllerProtocol)
 }

--- a/SL One trip search/Controller/UserJourneyController.swift
+++ b/SL One trip search/Controller/UserJourneyController.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 protocol UserJourneyControllerProtocol {
+    func attemptToRetreiveStoredJourney()
     var userJourney: UserJourney? {get}
     var start: Station? {get set}
     var destination: Station? {get set}
@@ -18,6 +19,16 @@ protocol UserJourneyControllerProtocol {
 class UserJourneyController: UserJourneyControllerProtocol {
     
     var userJourney: UserJourney?
+    private let persistService: PersistServiceProtocol
+    private let userJourneyPersistKey = "userJourneyPersistKey"
+    
+    init(persistService: PersistServiceProtocol) {
+        self.persistService = persistService
+    }
+    
+    func attemptToRetreiveStoredJourney() {
+        userJourney = persistService.retreive(UserJourney.self, valueForKey: userJourneyPersistKey)
+    }
     
     var start: Station? {
         didSet {
@@ -71,6 +82,7 @@ class UserJourneyController: UserJourneyControllerProtocol {
     
     private func createUserJourney(start: Station, destination: Station, timeUntilSearch: Int, monitorStationProximity: Bool) {
         userJourney = UserJourney(start: start, destination: destination, minutesUntilSearch: timeUntilSearch, monitorStationProximity: monitorStationProximity)
+        persistService.persist(value: userJourney!, forKey: userJourneyPersistKey)
     }
     
     

--- a/SL One trip search/Coordinator/MainCoordinator.swift
+++ b/SL One trip search/Coordinator/MainCoordinator.swift
@@ -25,14 +25,11 @@ class MainCoordinator {
     func start() {
         
         let journeyViewController = viewControllerFactory.journeyViewController
-        // Later on we will set a state controller on this
-        rootNavigationController.pushViewController(viewControllerFactory.journeyViewController, animated: false)
-        
+        journeyViewController.delegate = self
+        rootNavigationController.pushViewController(journeyViewController, animated: false)
+
         if stateController.userJourneyController.userJourney == nil {
-            let settingsViewController = viewControllerFactory.settingsViewController
-            settingsViewController.stateController = self.stateController
-            settingsViewController.delegate = self
-            rootNavigationController.pushViewController(settingsViewController, animated: false)
+            showSettings(animated: false)
         }
         
         window.rootViewController = rootNavigationController
@@ -46,6 +43,13 @@ class MainCoordinator {
         stationSearchVC.stateController = stateController
         stationSearchVC.delegate = self
         rootNavigationController.pushViewController(stationSearchVC, animated: true)
+    }
+    
+    fileprivate func showSettings(animated: Bool = true) {
+        let settingsViewController = viewControllerFactory.settingsViewController
+        settingsViewController.stateController = self.stateController
+        settingsViewController.delegate = self
+        rootNavigationController.pushViewController(settingsViewController, animated: animated)
     }
 
 }
@@ -63,5 +67,11 @@ extension MainCoordinator : SettingsViewControllerDelegate {
 extension MainCoordinator : SearchViewControllerDelegate {
     func didSelectStation() {
         rootNavigationController.popViewController(animated: true)
+    }
+}
+
+extension MainCoordinator : JourneyViewControllerDelegate {
+    func didPressSettings() {
+        showSettings()
     }
 }

--- a/SL One trip search/Coordinator/MainCoordinator.swift
+++ b/SL One trip search/Coordinator/MainCoordinator.swift
@@ -31,6 +31,7 @@ class MainCoordinator {
         if stateController.userJourneyController.userJourney == nil {
             let settingsViewController = viewControllerFactory.settingsViewController
             settingsViewController.stateController = self.stateController
+            settingsViewController.delegate = self
             rootNavigationController.pushViewController(settingsViewController, animated: false)
         }
         
@@ -38,5 +39,29 @@ class MainCoordinator {
         window.makeKeyAndVisible()
         
     }
+    
+    fileprivate func showSearchViewController(stationJourneyType: StationJourneyType) {
+        let stationSearchVC = viewControllerFactory.searchViewController
+        stationSearchVC.stationJourneyType = stationJourneyType
+        stationSearchVC.stateController = stateController
+        stationSearchVC.delegate = self
+        rootNavigationController.pushViewController(stationSearchVC, animated: true)
+    }
 
+}
+
+extension MainCoordinator : SettingsViewControllerDelegate {
+    func didTapStartTextField() {
+        showSearchViewController(stationJourneyType: .start)
+    }
+    
+    func didTapDestinationTextField() {
+        showSearchViewController(stationJourneyType: .destination)
+    }
+}
+
+extension MainCoordinator : SearchViewControllerDelegate {
+    func didSelectStation() {
+        rootNavigationController.popViewController(animated: true)
+    }
 }

--- a/SL One trip search/Info.plist
+++ b/SL One trip search/Info.plist
@@ -32,6 +32,11 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/SL One trip search/Model/Station.swift
+++ b/SL One trip search/Model/Station.swift
@@ -8,9 +8,68 @@
 
 import Foundation
 
+enum StationJourneyType {
+    case start, destination
+}
+
+enum StationDecodingError : Error {
+    case errorCreatingCoordinates
+}
+
 struct Station {
     let name: String
+    let area: String
     let id: String
     let lat: Double
     let long: Double
 }
+
+struct StationSearchResult : Decodable {
+    let values: [Station]
+    enum StationCodingResultKey : String, CodingKey {
+        case values = "ResponseData"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: StationCodingResultKey.self)
+        values = try container.decode([Station].self, forKey: .values)
+    }
+}
+
+extension Station : Decodable {
+    enum StationKey : String, CodingKey {
+        case name = "Name"
+        case id = "SiteId"
+        case X, Y
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: StationKey.self)
+        var tempName = try container.decode(String.self, forKey: .name)
+        id = try container.decode(String.self, forKey: .id)
+        var longString = try container.decode(String.self, forKey: .X)
+        var latString = try container.decode(String.self, forKey: .Y)
+        longString.insert(".", at: longString.index(longString.startIndex, offsetBy: 2))
+        latString.insert(".", at: longString.index(longString.startIndex, offsetBy: 2))
+        guard let long = Double(longString), let lat = Double(latString) else {
+            throw StationDecodingError.errorCreatingCoordinates
+        }
+        self.lat = lat
+        self.long = long
+        if let areaParentheseStartIndex = tempName.firstIndex(of: "("),
+            let areaParentheseEndIndex = tempName.firstIndex(of: ")") {
+            let textStartIndex = tempName.index(areaParentheseStartIndex, offsetBy: 1)
+            
+            area = String(tempName[textStartIndex..<areaParentheseEndIndex])
+            let removeStartIndex = tempName.index(areaParentheseStartIndex, offsetBy: -1)
+            tempName.removeSubrange(removeStartIndex...areaParentheseEndIndex)
+        } else {
+            area = ""
+        }
+        
+        name = tempName
+    }
+}
+
+
+

--- a/SL One trip search/Model/UserJourney.swift
+++ b/SL One trip search/Model/UserJourney.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct UserJourney {
+struct UserJourney : Codable {
     let start: Station
     let destination: Station
     let minutesUntilSearch: Int

--- a/SL One trip search/Service/PersistService.swift
+++ b/SL One trip search/Service/PersistService.swift
@@ -1,0 +1,41 @@
+//
+//  PersistService.swift
+//  SL One trip search
+//
+//  Created by Emil Lundgren on 2018-10-19.
+//  Copyright © 2018 Kebne. All rights reserved.
+//
+
+import Foundation
+
+protocol UserDefaultProtocol {
+    func data(forKey: String) ->Data?
+    func set(_ value: Any?, forKey: String)
+}
+
+extension UserDefaults : UserDefaultProtocol {}
+
+protocol PersistServiceProtocol {
+    func persist<T: Encodable>(value: T, forKey key: String)
+    func retreive<T: Decodable>(_ type: T.Type, valueForKey key: String) ->T?
+    init(_ userDefaults: UserDefaultProtocol)
+}
+
+class PersistService : PersistServiceProtocol {
+    
+    private let userDefaults: UserDefaultProtocol
+    required init(_ userDefaults: UserDefaultProtocol = UserDefaults.standard) {
+        self.userDefaults = userDefaults
+    }
+    
+    func persist<T: Encodable>(value: T, forKey key: String) {
+        if let encoded = try? JSONEncoder().encode(value) {
+            userDefaults.set(encoded, forKey: key)
+        }
+    }
+    
+    func retreive<T: Decodable>(_ type: T.Type, valueForKey key: String) ->T? {
+        guard let data = userDefaults.data(forKey: key) else {return nil}
+        return try? JSONDecoder().decode(type, from: data)
+    }
+}

--- a/SL One trip search/Service/SLSearch.swift
+++ b/SL One trip search/Service/SLSearch.swift
@@ -1,0 +1,81 @@
+//
+//  SLSearch.swift
+//  SL One trip search
+//
+//  Created by Emil Lundgren on 2018-10-18.
+//  Copyright © 2018 Kebne. All rights reserved.
+//
+
+import Foundation
+
+enum EndpointError : Error {
+    case corruptUrlError
+    case corruptUrlResponse
+    case corruptData
+}
+
+enum Result<T> {
+    case success(T)
+    case failure(Error)
+}
+
+protocol SLSearch {
+    associatedtype ResultType
+    typealias SearchCallback = (Result<ResultType>)->Void
+    func searchWith(request: SearchRequest, callback: @escaping SearchCallback)
+    init(urlSession: URLSessionProtocol)
+}
+
+
+protocol URLSessionDataTaskProtocol { func resume() }
+extension URLSessionDataTask : URLSessionDataTaskProtocol {}
+
+protocol URLSessionProtocol {
+    func dataTask(with request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol
+}
+
+extension URLSession : URLSessionProtocol {
+    func dataTask(with request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
+        return dataTask(with: request, completionHandler: completion) as URLSessionDataTaskProtocol
+    }
+}
+
+class SearchService<T: Decodable> : SLSearch {
+    private let urlSession: URLSessionProtocol
+    
+    required init(urlSession: URLSessionProtocol = URLSession.shared) {
+        self.urlSession = urlSession
+    }
+    
+    
+    func searchWith(request: SearchRequest, callback: @escaping (Result<T>) -> Void) {
+    
+        var urlrequest = URLRequest(url: request.url)
+        urlrequest.httpMethod = "GET"
+        
+        let task = urlSession.dataTask(with: urlrequest) {data, response, error in
+            guard error == nil else {
+                callback(Result.failure(error!))
+                return
+            }
+            
+            guard let response = response as? HTTPURLResponse, response.statusCode == 200 else {
+                callback(Result.failure(EndpointError.corruptUrlResponse))
+                return
+            }
+            
+            guard let data = data else {
+                callback(Result.failure(EndpointError.corruptData))
+                return
+            }
+            
+            do {
+                let result = try JSONDecoder().decode(T.self, from: data)
+                callback(Result.success(result))
+            } catch let e {
+                callback(Result.failure(e))
+            }
+        }
+        task.resume()
+    }
+}

--- a/SL One trip search/Service/SearchRequest.swift
+++ b/SL One trip search/Service/SearchRequest.swift
@@ -1,0 +1,40 @@
+//
+//  SearchRequest.swift
+//  SL One trip search
+//
+//  Created by Emil Lundgren on 2018-10-18.
+//  Copyright © 2018 Kebne. All rights reserved.
+//
+
+import Foundation
+
+protocol SearchRequest {
+    var url: URL {get}
+}
+
+enum SLAPIURLComponentKeys {
+    static let httpScheme  = "http"
+    static let slHost = "api.sl.se"
+    static let key = "key"
+}
+
+struct StationSearchRequest : SearchRequest {
+    let url: URL
+    private let apiPath = "api2/typeahead.json"
+    init?(searchString: String) {
+        var urlComponents = URLComponents()
+        urlComponents.scheme = SLAPIURLComponentKeys.httpScheme
+        urlComponents.host = SLAPIURLComponentKeys.slHost
+        urlComponents.path = "/" + apiPath
+        
+        let keyQuery = URLQueryItem(name: SLAPIURLComponentKeys.key, value: Environment.stationAPIKey)
+        let searchStringQuery = URLQueryItem(name: "searchstring", value: searchString)
+        let stationsOnlyQuery = URLQueryItem(name: "stationsonly", value: "true")
+        urlComponents.queryItems = [keyQuery, searchStringQuery, stationsOnlyQuery]
+        
+        guard let url = urlComponents.url else {
+            return nil
+        }
+        self.url = url
+    }
+}

--- a/SL One trip search/Service/SearchRequest.swift
+++ b/SL One trip search/Service/SearchRequest.swift
@@ -38,3 +38,5 @@ struct StationSearchRequest : SearchRequest {
         self.url = url
     }
 }
+
+

--- a/SL One trip search/View/JourneyViewController.swift
+++ b/SL One trip search/View/JourneyViewController.swift
@@ -8,11 +8,21 @@
 
 import UIKit
 
-class JourneyViewController: UIViewController, StoryboardInstantiable {
+protocol JourneyViewControllerDelegate : AnyObject {
+    func didPressSettings()
+}
 
+class JourneyViewController: UIViewController, StoryboardInstantiable {
+    
+    weak var delegate: JourneyViewControllerDelegate?
+    
+    @IBAction func didPressSettingsButton(_ sender: UIBarButtonItem) {
+        delegate?.didPressSettings()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
+        
     }
 
 

--- a/SL One trip search/View/SearchViewController.swift
+++ b/SL One trip search/View/SearchViewController.swift
@@ -65,14 +65,13 @@ extension SearchViewController: UISearchResultsUpdating {
             guard let self = self else {return}
             switch result {
             case .success(let stationSearchResult):
-                self.dataSource.stations = stationSearchResult.values
+                self.dataSource.stations = stationSearchResult.values.map({$0.station})
             case .failure(_):
                 self.dataSource.stations = [Station]()
             }
             DispatchQueue.main.async {
                 self.searchTableView.reloadData()
             }
-            
         }
     }
 

--- a/SL One trip search/View/SearchViewController.swift
+++ b/SL One trip search/View/SearchViewController.swift
@@ -8,14 +8,100 @@
 
 import UIKit
 
+protocol SearchViewControllerDelegate : AnyObject {
+    func didSelectStation()
+}
+
 class SearchViewController: UIViewController {
 
+    @IBOutlet weak var searchTableView: UITableView!
+    var stationJourneyType: StationJourneyType!
+    var stateController: StateControllerProtocol!
+    let dataSource = SearchResultTableViewDataSource()
+    let searchService = SearchService<StationSearchResult>()
+    let searchController = UISearchController(searchResultsController: nil)
+    weak var delegate: SearchViewControllerDelegate?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        searchTableView.delegate = self
+        searchTableView.dataSource = dataSource
+        searchTableView.tableFooterView = UIView(frame: CGRect.zero)
+        
+        searchController.searchResultsUpdater = self
+        searchController.obscuresBackgroundDuringPresentation = false
+        searchController.searchBar.placeholder = "Sök station"
+        navigationItem.hidesSearchBarWhenScrolling = false
+        navigationItem.searchController = searchController
+        definesPresentationContext = true
     }
 
+}
+
+extension SearchViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch stationJourneyType! {
+        case .start:
+            stateController.userJourneyController.start = dataSource.stations[indexPath.row]
+        case .destination:
+            stateController.userJourneyController.destination = dataSource.stations[indexPath.row]
+        }
+        
+        delegate?.didSelectStation()
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return CGFloat(StationTableViewCell.height)
+    }
+}
+
+extension SearchViewController: UISearchResultsUpdating {
+    func updateSearchResults(for searchController: UISearchController) {
+        guard let searchText = searchController.searchBar.text, searchText.count > 0, let searchRequest = StationSearchRequest(searchString: searchText) else {
+            dataSource.stations = [Station]()
+            searchTableView.reloadData()
+            return}
+        searchService.searchWith(request: searchRequest) {[weak self] result in
+            guard let self = self else {return}
+            switch result {
+            case .success(let stationSearchResult):
+                self.dataSource.stations = stationSearchResult.values
+            case .failure(_):
+                self.dataSource.stations = [Station]()
+            }
+            DispatchQueue.main.async {
+                self.searchTableView.reloadData()
+            }
+            
+        }
+    }
+
+}
+
+class SearchResultTableViewDataSource : NSObject, UITableViewDataSource {
+
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let searchResultCell = tableView.dequeueReusableCell(withIdentifier: StationTableViewCell.reuseIdentifier, for: indexPath) as! StationTableViewCell
+        searchResultCell.viewModel = viewModels[indexPath.row]
+        
+        return searchResultCell
+    }
+    
+    var stations = [Station]() {
+        didSet {
+            viewModels = stations.map({StationTableViewCell.ViewModel(station: $0)})
+        }
+    }
+    private var viewModels = [StationTableViewCell.ViewModel]()
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModels.count
+    }
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
 }
 
 extension SearchViewController : StoryboardInstantiable {}

--- a/SL One trip search/View/StationTableViewCell.swift
+++ b/SL One trip search/View/StationTableViewCell.swift
@@ -1,0 +1,42 @@
+//
+//  StationTableViewCell.swift
+//  SL One trip search
+//
+//  Created by Emil Lundgren on 2018-10-18.
+//  Copyright © 2018 Kebne. All rights reserved.
+//
+
+import UIKit
+
+class StationTableViewCell: UITableViewCell {
+    
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var additionalNameLabel: UILabel!
+    static let height = 65
+    static let reuseIdentifier = "StationTableViewCell"
+    
+    var viewModel: ViewModel = ViewModel() {
+        didSet {
+            nameLabel.text = viewModel.name
+            additionalNameLabel.text = viewModel.additionalName
+        }
+    }
+
+}
+
+extension StationTableViewCell {
+    struct ViewModel {
+        let name: String
+        let additionalName: String
+        
+        init() {
+            name = ""
+            additionalName = ""
+        }
+        
+        init(station: Station) {
+            name = station.name
+            additionalName = station.area
+        }
+    }
+}

--- a/SL One trip searchTests/PersistServiceTests.swift
+++ b/SL One trip searchTests/PersistServiceTests.swift
@@ -1,0 +1,62 @@
+//
+//  PersistServiceTests.swift
+//  SL One trip searchTests
+//
+//  Created by Emil Lundgren on 2018-10-19.
+//  Copyright © 2018 Kebne. All rights reserved.
+//
+
+import XCTest
+@testable import SL_One_trip_search
+
+class PersistServiceTests: XCTestCase {
+    
+    var sut: PersistService!
+    var mockUserDefaults: MockUserDefaults!
+
+    override func setUp() {
+        mockUserDefaults = MockUserDefaults()
+        sut = PersistService(mockUserDefaults)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockUserDefaults = nil
+    }
+
+    func test_callsSetValue_onPersist() {
+        mockUserDefaults.didCallSet = false
+        sut.persist(value: PersistStubGenerator.userJourney, forKey: "key")
+        XCTAssertTrue(mockUserDefaults.didCallSet)
+    }
+    
+    func test_retreiveUserJourney() {
+        let userJourney: UserJourney? = sut.retreive(UserJourney.self, valueForKey: "key")
+        XCTAssertNotNil(userJourney)
+    }
+
+}
+
+
+class PersistStubGenerator {
+    
+    static var userJourney : UserJourney {
+        return UserJourney(start: UserJourneyControllerTests.mockStart,
+                           destination: UserJourneyControllerTests.mockEnd,
+                           minutesUntilSearch: 5, monitorStationProximity: true)
+    }
+}
+
+class MockUserDefaults : UserDefaultProtocol {
+    
+    var didCallSet = false
+    
+    func data(forKey: String) -> Data? {
+        return try? JSONEncoder().encode(PersistStubGenerator.userJourney)
+    }
+    
+    func set(_ value: Any?, forKey: String) {
+        didCallSet = true
+    }
+
+}

--- a/SL One trip searchTests/SLSearchTests.swift
+++ b/SL One trip searchTests/SLSearchTests.swift
@@ -1,0 +1,98 @@
+//
+//  SLSearchTests.swift
+//  SL One trip searchTests
+//
+//  Created by Emil Lundgren on 2018-10-18.
+//  Copyright © 2018 Kebne. All rights reserved.
+//
+
+import XCTest
+
+@testable import SL_One_trip_search
+
+class SLSearchTests: XCTestCase {
+    
+    var sut: SearchService<StationSearchResult>!
+    var mockURLSession: MockURLSession!
+
+    override func setUp() {
+        mockURLSession = MockURLSession()
+        sut = SearchService<StationSearchResult>(urlSession: mockURLSession)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockURLSession = nil
+    }
+    
+    func test_handlesCorrectJSON_callbackWith_StationResult() {
+        
+        mockURLSession.correctJson = true
+        mockURLSession.error = nil
+        mockURLSession.response200 = true
+        
+        var response: StationSearchResult? = nil
+        
+        guard let searchRequest = StationSearchRequest(searchString: "searchString") else {
+            XCTFail("Couldn't create search request.")
+            return
+        }
+        sut.searchWith(request: searchRequest) {result in
+            
+            switch result {
+            case .success(let stationRes): response = stationRes
+            default:
+                XCTFail("Failed to convert correct JSON to Station response.")
+            }
+            
+        }
+        XCTAssertNotNil(response)
+    }
+
+}
+
+class MockURLSession : URLSessionProtocol {
+
+    var correctJson: Bool = true
+    var response200: Bool = true
+    var error: Error?
+
+    func dataTask(with request: URLRequest, completion: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTaskProtocol {
+        let statusCode = response200 ? 200 : 400
+        let urlResponse = HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)
+        
+        let jsonData = correctJson ? StubGenerator.correctStationJSONString.data(using: .utf8) : StubGenerator.brokenStationJSONString.data(using: .utf8)
+        completion(jsonData, urlResponse, error)
+        
+        
+        return MockURLSessionDataTask()
+    }
+}
+
+class MockURLSessionDataTask : URLSessionDataTaskProtocol {
+    
+    var didCallResume: Bool = false
+    func resume() {
+        didCallResume = true
+    }
+}
+
+class StubGenerator {
+    
+    static var correctStationJSONString : String {
+        return """
+        { "StatusCode": 0, "Message": null, "ExecutionTime": 0, "ResponseData": [
+        { "Name": "Slussen (Stockholm)", "SiteId": "9192", "Type": "Station", "X": "18071860", "Y": "59320284" },
+        { "Name": "Slumnäsvägen (Tyresö)", "SiteId": "8056", "Type": "Station", "X": "18273946", "Y": "59248604" } ]}
+"""
+    }
+    
+    static var brokenStationJSONString : String {
+        return """
+        { "StatusCode": 0, "Message": null, "ExecutionTime": 0, "ResponseData": [
+        { "Name": "Slussen (Stockholm)", "SiteId": "9192", "Type": "Station", "X": "18071860", "Y": "59320284" },
+        { "Name": "Slumnäsvägen (Tyresö)", "SiteId": "8056", "Type": "Station", "X": "18273946", "Y": "59248604" }
+        """
+    }
+    
+}

--- a/SL One trip searchTests/SLSearchTests.swift
+++ b/SL One trip searchTests/SLSearchTests.swift
@@ -48,6 +48,81 @@ class SLSearchTests: XCTestCase {
         }
         XCTAssertNotNil(response)
     }
+    
+    func test_handlesCorruptJSON_callbackWith_StationResult() {
+        
+        mockURLSession.correctJson = false
+        mockURLSession.error = nil
+        mockURLSession.response200 = true
+        
+        var response: StationSearchResult? = nil
+        var error: Error?
+        
+        guard let searchRequest = StationSearchRequest(searchString: "searchString") else {
+            XCTFail("Couldn't create search request.")
+            return
+        }
+        sut.searchWith(request: searchRequest) {result in
+            
+            switch result {
+            case .success(let stationRes): response = stationRes
+            case.failure(let requestError): error = requestError
+            }
+            
+        }
+        XCTAssertNotNil(error)
+        XCTAssertNil(response)
+    }
+    
+    func test_errorCallback_httpStatusCode_not200() {
+        
+        mockURLSession.correctJson = false
+        mockURLSession.error = nil
+        mockURLSession.response200 = false
+        
+        var response: StationSearchResult? = nil
+        var error: Error?
+        
+        guard let searchRequest = StationSearchRequest(searchString: "searchString") else {
+            XCTFail("Couldn't create search request.")
+            return
+        }
+        sut.searchWith(request: searchRequest) {result in
+            
+            switch result {
+            case .success(let stationRes): response = stationRes
+            case.failure(let requestError): error = requestError
+            }
+            
+        }
+        XCTAssertNotNil(error)
+        XCTAssertNil(response)
+    }
+    
+    func test_errorCallback_onCompletionError() {
+        
+        mockURLSession.correctJson = false
+        mockURLSession.error = EndpointError.corruptUrlError
+        mockURLSession.response200 = true
+        
+        var response: StationSearchResult? = nil
+        var error: Error?
+        
+        guard let searchRequest = StationSearchRequest(searchString: "searchString") else {
+            XCTFail("Couldn't create search request.")
+            return
+        }
+        sut.searchWith(request: searchRequest) {result in
+            
+            switch result {
+            case .success(let stationRes): response = stationRes
+            case.failure(let requestError): error = requestError
+            }
+            
+        }
+        XCTAssertNotNil(error)
+        XCTAssertNil(response)
+    }
 
 }
 

--- a/SL One trip searchTests/SearchRequestTest.swift
+++ b/SL One trip searchTests/SearchRequestTest.swift
@@ -1,0 +1,26 @@
+//
+//  SearchRequestTest.swift
+//  SL One trip searchTests
+//
+//  Created by Emil Lundgren on 2018-10-18.
+//  Copyright © 2018 Kebne. All rights reserved.
+//
+
+import XCTest
+@testable import SL_One_trip_search
+
+class SearchRequestTest: XCTestCase {
+
+    func test_stationSearch_buildsCorrectURL() {
+        
+        let searchString = "station"
+        let expectedResult = "http://api.sl.se/api2/typeahead.json?key=\(Environment.stationAPIKey)&searchstring=\(searchString)&stationsonly=true"
+        guard let request = StationSearchRequest(searchString: searchString) else {
+            XCTFail("Station search request was not able to be created.")
+            return
+        }
+        
+        XCTAssertEqual(expectedResult, request.url.absoluteString)
+    }
+
+}

--- a/SL One trip searchTests/SettingsViewModelTests.swift
+++ b/SL One trip searchTests/SettingsViewModelTests.swift
@@ -1,0 +1,38 @@
+//
+//  SettingsViewModelTests.swift
+//  SL One trip searchTests
+//
+//  Created by Emil Lundgren on 2018-10-18.
+//  Copyright © 2018 Kebne. All rights reserved.
+//
+
+import XCTest
+@testable import SL_One_trip_search
+
+class SettingsViewModelTests: XCTestCase {
+
+    func test_initWith_onlyStartStation_showCorrectValues() {
+        
+        let sut = SettingsViewController.ViewModel(userJourney: nil, tempStart: UserJourneyControllerTests.mockStart, tempDestination: nil)
+        XCTAssertEqual(sut.originText, UserJourneyControllerTests.mockStart.name)
+        XCTAssertEqual(sut.destinationText, "")
+        
+    }
+    
+    func test_initWith_onlyEndStation_showCorrectValues() {
+        
+        let sut = SettingsViewController.ViewModel(userJourney: nil, tempStart: nil, tempDestination: UserJourneyControllerTests.mockEnd)
+        XCTAssertEqual(sut.destinationText, UserJourneyControllerTests.mockEnd.name)
+        XCTAssertEqual(sut.originText, "")
+        
+    }
+    
+    func test_initWith_userJourneyAnd_showCorrectValues() {
+        
+        let userJourney = UserJourney(start: UserJourneyControllerTests.mockStart, destination: UserJourneyControllerTests.mockEnd, minutesUntilSearch: 2, monitorStationProximity: false)
+        let sut = SettingsViewController.ViewModel(userJourney: userJourney, tempStart: nil, tempDestination: nil)
+        XCTAssertEqual(sut.destinationText, userJourney.destination.name)
+        XCTAssertEqual(sut.originText, userJourney.start.name)
+        
+    }
+}

--- a/SL One trip searchTests/StationTests.swift
+++ b/SL One trip searchTests/StationTests.swift
@@ -1,0 +1,35 @@
+//
+//  StationTests.swift
+//  SL One trip searchTests
+//
+//  Created by Emil Lundgren on 2018-10-19.
+//  Copyright © 2018 Kebne. All rights reserved.
+//
+
+import XCTest
+@testable import SL_One_trip_search
+
+class StationTests: XCTestCase {
+
+    func test_constructsCorrectStation_fromSLStation() {
+        
+        let expectedArea = "Stockholm"
+        let expectedName = "Slussen"
+        let expectedLat = 18.071860
+        let expectedLong = 59.320284
+        let slStationX = "\(expectedLong)".replacingOccurrences(of: ".", with: "")
+        let slStationY = "\(expectedLat)".replacingOccurrences(of: ".", with: "")
+        let slStationName = expectedName + " (" + expectedArea + ")"
+        let id = "id"
+        
+        let slStation = SLStation(name: slStationName, id: id, x: slStationX, y: slStationY)
+        let station = slStation.station
+        
+        XCTAssertEqual(station.name, expectedName)
+        XCTAssertEqual(station.area, expectedArea)
+        XCTAssertEqual(station.lat, expectedLat)
+        XCTAssertEqual(station.long, expectedLong)
+        XCTAssertEqual(station.id, id)
+    }
+
+}

--- a/SL One trip searchTests/UserJourneyControllerTests.swift
+++ b/SL One trip searchTests/UserJourneyControllerTests.swift
@@ -12,13 +12,22 @@ import XCTest
 class UserJourneyControllerTests: XCTestCase {
     
     var sut: UserJourneyController!
+    var mockedPersistService: MockPersistService!
 
     override func setUp() {
-        sut = UserJourneyController()
+        mockedPersistService = MockPersistService(UserDefaults.standard)
+        sut = UserJourneyController(persistService: mockedPersistService)
     }
 
     override func tearDown() {
         sut = nil
+    }
+    
+    func test_callsRetreive_onPersistService() {
+        mockedPersistService.didCallRetreive = false
+        sut.attemptToRetreiveStoredJourney()
+        
+        XCTAssertTrue(mockedPersistService.didCallRetreive)
     }
 
     func test_noUserCreated_withoutAllStations() {
@@ -96,3 +105,25 @@ class UserJourneyControllerTests: XCTestCase {
     }
 
 }
+
+class MockPersistService : PersistServiceProtocol {
+    
+    var didCallRetreive = false
+    
+    func persist<T>(value: T, forKey key: String) where T : Encodable {
+        
+    }
+    
+    func retreive<T>(_ type: T.Type, valueForKey key: String) -> T? where T : Decodable {
+        didCallRetreive = true
+        return nil
+    }
+    
+    required init(_ userDefaults: UserDefaultProtocol) {
+        
+    }
+    
+    
+}
+
+

--- a/SL One trip searchTests/UserJourneyControllerTests.swift
+++ b/SL One trip searchTests/UserJourneyControllerTests.swift
@@ -24,7 +24,7 @@ class UserJourneyControllerTests: XCTestCase {
     func test_noUserCreated_withoutAllStations() {
         
         sut.userJourney = nil
-        sut.start = mockStart
+        sut.start = UserJourneyControllerTests.mockStart
         sut.destination = nil
         
         XCTAssertNil(sut.userJourney)
@@ -34,8 +34,8 @@ class UserJourneyControllerTests: XCTestCase {
     func test_userIsCreated_AllStationsAreSet() {
   
         sut.userJourney = nil
-        sut.start = mockStart
-        sut.destination = mockEnd
+        sut.start = UserJourneyControllerTests.mockStart
+        sut.destination = UserJourneyControllerTests.mockEnd
         sut.destination = nil
         
         XCTAssertNotNil(sut.userJourney)
@@ -44,23 +44,23 @@ class UserJourneyControllerTests: XCTestCase {
     func test_startStopStationsAreCorrect() {
         
         sut.userJourney = nil
-        sut.start = mockStart
-        sut.destination = mockEnd
+        sut.start = UserJourneyControllerTests.mockStart
+        sut.destination = UserJourneyControllerTests.mockEnd
         
         guard let journey = sut.userJourney else {
             XCTFail( "Journey shouldn't be nil here!")
             return
         }
         
-        XCTAssertEqual(journey.start.name, mockStart.name)
-        XCTAssertEqual(journey.destination.name, mockEnd.name)
+        XCTAssertEqual(journey.start.name, UserJourneyControllerTests.mockStart.name)
+        XCTAssertEqual(journey.destination.name, UserJourneyControllerTests.mockEnd.name)
         
     }
     
     func test_TimeValue_isSet() {
         sut.userJourney = nil
-        sut.start = mockStart
-        sut.destination = mockEnd
+        sut.start = UserJourneyControllerTests.mockStart
+        sut.destination = UserJourneyControllerTests.mockEnd
         let minutes = 5
         sut.timeFromNowUntilSearch = minutes
         
@@ -74,8 +74,8 @@ class UserJourneyControllerTests: XCTestCase {
     
     func test_MonitorValue_isSet() {
         sut.userJourney = nil
-        sut.start = mockStart
-        sut.destination = mockEnd
+        sut.start = UserJourneyControllerTests.mockStart
+        sut.destination = UserJourneyControllerTests.mockEnd
         let monitor = false
         sut.monitorStationProximity = monitor
         
@@ -87,12 +87,12 @@ class UserJourneyControllerTests: XCTestCase {
         XCTAssertEqual(journey.monitorStationProximity, monitor)
     }
     
-    var mockStart : Station {
-        return Station(name: "Start", id: "10", lat: 0.0, long: 0.0)
+    static var mockStart : Station {
+        return Station(name: "Start",area: "area", id: "10", lat: 0.0, long: 0.0)
     }
     
-    var mockEnd : Station {
-        return Station(name: "Destination", id: "11", lat: 0.0, long: 0.0)
+    static var mockEnd : Station {
+        return Station(name: "Destination",area: "area", id: "11", lat: 0.0, long: 0.0)
     }
 
 }


### PR DESCRIPTION
La till en vy för att söka efter stationer med trafiklabs API:er.
En generisk klass `SearchService`som conformar till protokollet `SLSearch`. 
En URLSession injectas vid instantiering och URLSession och URLSessionDataTask har blivit abstraherade i protokoll för att kunna testa.
Man skickar in en instans som conformar till `SearchRequest`till metoden `searchWith`på `SearchService`-instansen. Man får callback och vid lyckat resultat den typ som klassen är generisk för.
